### PR TITLE
Add look to unfreeze level pieces

### DIFF
--- a/Assets/LevelGeneration/LevelGenerator.cs
+++ b/Assets/LevelGeneration/LevelGenerator.cs
@@ -48,6 +48,8 @@ namespace LevelGeneration
         levelPiece = walkwayGenerator.AddPieceToWalkway(lastPieceFinalWalkoffPoint, word, lastPieceWord);
       }
 
+      levelPiece.GetComponent<LevelPiecePositioner>().FreezeInPlace(); // Peac5
+
       levelPiecesSpawned.Add(levelPiece);
       return levelPiece;
     }

--- a/Assets/LevelGeneration/LevelPiece/LevelPiecePositioner.cs
+++ b/Assets/LevelGeneration/LevelPiece/LevelPiecePositioner.cs
@@ -22,6 +22,7 @@ namespace LevelGeneration
         public Vector3 targetPos { get; private set; }
         public Quaternion targetRot { get; private set; }
         public bool reachedFinalPosition { get; private set; }
+        public bool isFrozen { get; private set; } // P6b4a
 
         //components
         Collider[] collidersToDisable;
@@ -43,7 +44,10 @@ namespace LevelGeneration
         {
             this.targetPos = targetPosition;
             this.targetRot = targetRotation;
-            StartCoroutine(MoveAnimation());
+            if (!isFrozen) // P86af
+            {
+                StartCoroutine(MoveAnimation());
+            }
         }
 
         IEnumerator MoveAnimation()
@@ -154,6 +158,16 @@ namespace LevelGeneration
             Vector3 finalWalkOffPoint = targetPos + targetRot * scaledLocalWalkOffPoint;
             return finalWalkOffPoint;
         }
+
+        public void FreezeInPlace() // P6b4a
+        {
+            isFrozen = true;
+        }
+
+        public void UnfreezeAndMoveToPosition() // P502e
+        {
+            isFrozen = false;
+            MoveWithAnimation(targetPos, targetRot);
+        }
     }
 }
-

--- a/Assets/LevelGeneration/WalkwayPieceFactory.cs
+++ b/Assets/LevelGeneration/WalkwayPieceFactory.cs
@@ -21,7 +21,7 @@ namespace LevelGeneration
       GameObject piece = Instantiate(walkwayPiecePrefab, spawnPos, Quaternion.identity);
       piece.transform.up = Vector3.back;
       piece.GetComponentInChildren<TMP_Text>().text = pieceWord;
-      piece.GetComponent<LevelPiecePositioner>().MoveWithSimpleAnimation(finalPos, finalRot);
+      piece.GetComponent<LevelPiecePositioner>().FreezeInPlace(); // Pe0f4
       return piece;
     }
 
@@ -29,7 +29,7 @@ namespace LevelGeneration
     {
       GameObject piece = levelPieceMolds.CopyNextMold();
       piece.GetComponentInChildren<TMP_Text>().text = pieceWord;
-      piece.GetComponent<LevelPiecePositioner>().MoveWithAnimation(targetPos, targetRot);
+      piece.GetComponent<LevelPiecePositioner>().FreezeInPlace(); // Pafb9
       return piece;
     }
 
@@ -38,6 +38,7 @@ namespace LevelGeneration
       GameObject piece = GameObject.Instantiate(walkwayPiecePrefab);
       piece.GetComponentInChildren<LevelPiecePositioner>().SetPosition(pos, rot);
       piece.GetComponentInChildren<TMP_Text>().text = pieceWord;
+      piece.GetComponent<LevelPiecePositioner>().FreezeInPlace(); // P6081
       return piece;
     }
 

--- a/Assets/Player/Archive/InteractionScanner.cs
+++ b/Assets/Player/Archive/InteractionScanner.cs
@@ -42,6 +42,7 @@ public class InteractionScanner : MonoBehaviour
                 {
                     SwitchHighlightedItem(interactable);
                 }
+                OnLookAt(interactable); // P6c40
             }
             else
             {
@@ -67,6 +68,15 @@ public class InteractionScanner : MonoBehaviour
         {
             highlightedInteractable.RemoveHighlight();
             highlightedInteractable = null;
+        }
+    }
+
+    private void OnLookAt(Interactable interactable) // P00f1
+    {
+        LevelPiecePositioner levelPiecePositioner = interactable.GetComponent<LevelPiecePositioner>();
+        if (levelPiecePositioner != null && levelPiecePositioner.isFrozen)
+        {
+            levelPiecePositioner.UnfreezeAndMoveToPosition();
         }
     }
 }


### PR DESCRIPTION
Implement the feature where level pieces freeze in place and unfreeze when looked at by the player.

* **LevelPiecePositioner.cs**
  - Add `isFrozen` property to track if a piece is frozen.
  - Add `FreezeInPlace` method to freeze the level piece.
  - Add `UnfreezeAndMoveToPosition` method to unfreeze and move the level piece.
  - Modify `MoveWithAnimation` method to check if the piece is frozen before moving.

* **InteractionScanner.cs**
  - Add `OnLookAt` method to handle the player looking at an interactable object.
  - Modify `ScanForItem` method to call `OnLookAt` when the player looks at a frozen level piece.

* **LevelGenerator.cs**
  - Modify `SpawnNextPiece` method to freeze the level piece in place after spawning.

* **WalkwayPieceFactory.cs**
  - Modify `SpawnAboveTargetAndMoveIntoPlace` method to freeze the level piece in place after spawning.
  - Modify `InstantiateInFrontOfCameraAnMoveIntoPlace` method to freeze the level piece in place after spawning.
  - Modify `InstantiateAtFinalPosition` method to freeze the level piece in place after spawning.

